### PR TITLE
Migrate to use v0.14 API

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,8 @@
 language: ruby
 rvm:
-  - 2.3.0
-  - 2.2.0
-  - 2.1.0
-  - 2.0.0
-  - 1.9.3
+  - 2.4.2
+  - 2.3.5
+  - 2.2
+  - 2.1
 before_install:
   - gem update --remote bundler

--- a/README.md
+++ b/README.md
@@ -22,11 +22,12 @@ Or install it yourself as:
   remove_tag_prefix raw
   add_tag_prefix filtered
 
-  <filter>
+  <eval>
     config @hostname = `hostname -s`.chomp
-
+  </eval>
+  <rule>
     filter "[[tag, @hostname].join('.'), time, record] if record['method'] == 'GET'"
-  </filter>
+  </rule>
 </match>
 ```
 
@@ -38,11 +39,12 @@ Or install it yourself as:
   add_tag_prefix filtered
   requires yaml # comma separated values
 
-  <filter>
+  <eval>
     config @hostname = YAML.load({'hostname' => 'web01'})['hostname']
-
+  </eval>
+  <rule>
     filter "[[tag, @hostname].join('.'), time, record] if record['method'] == 'GET'"
-  </filter>
+  </rule>
 </match>
 ```
 
@@ -58,12 +60,12 @@ Should return [time, record].
 
     <filter **>
       @type eval
-      <filter>
+      <rule>
         filter "[time, record] if record['status'] == '404'"
-      </filter>
-      <filter>
+      </rule>
+      <rule>
         filter "[time, record] if record['status'] == 'POST'"
-      </filter>
+      </rule>
     </filter>
 
 
@@ -71,18 +73,18 @@ Should return [time, record].
 
     <filter **>
       @type eval
-      <filter>
+      <rule>
         filter "record['status'] = record['status'].to_i; [time, record]"
-      </filter>
+      </rule>
     </filter>
 
 ### modify record(add value):
 
     <filter **>
       @type eval
-      <filter>
+      <rule>
         filter "record['user_id'] = record['message'].split(':').last.to_i; [time, record]"
-      </filter>
+      </rule>
     </filter>
 
 #### input
@@ -106,10 +108,10 @@ Should return [time, record].
 Can not be used expression substitution.
 ```
 <match raw.apache.access>
-  @type eval_filter
-  <filter>
+  @type eval_rule
+  <rule>
     filter "#{tag}"
-  </filter>
+  </rule>
 </match>
 ```
 

--- a/README.md
+++ b/README.md
@@ -18,27 +18,31 @@ Or install it yourself as:
 
 ```
 <match raw.apache.access>
-  type eval_filter
+  @type eval_filter
   remove_tag_prefix raw
   add_tag_prefix filtered
 
-  config1 @hostname = `hostname -s`.chomp
+  <filter>
+    config @hostname = `hostname -s`.chomp
 
-  filter1 "[[tag, @hostname].join('.'), time, record] if record['method'] == 'GET'"
+    filter "[[tag, @hostname].join('.'), time, record] if record['method'] == 'GET'"
+  </filter>
 </match>
 ```
 
 ### require libraries
 ```
 <match raw.apache.access>
-  type eval_filter
+  @type eval_filter
   remove_tag_prefix raw
   add_tag_prefix filtered
   requires yaml # comma separated values
 
-  config1 @hostname = YAML.load({'hostname' => 'web01'})['hostname']
+  <filter>
+    config @hostname = YAML.load({'hostname' => 'web01'})['hostname']
 
-  filter1 "[[tag, @hostname].join('.'), time, record] if record['method'] == 'GET'"
+    filter "[[tag, @hostname].join('.'), time, record] if record['method'] == 'GET'"
+  </filter>
 </match>
 ```
 
@@ -53,24 +57,32 @@ Should return [time, record].
 ### filter:
 
     <filter **>
-      type eval
-      filter1 "[time, record] if record['status'] == '404'"
-      filter2 "[time, record] if record['status'] == 'POST'"
+      @type eval
+      <filter>
+        filter "[time, record] if record['status'] == '404'"
+      </filter>
+      <filter>
+        filter "[time, record] if record['status'] == 'POST'"
+      </filter>
     </filter>
 
 
 ### typecast(string to integer):
 
     <filter **>
-      type eval
-      filter1 "record['status'] = record['status'].to_i; [time, record]"
+      @type eval
+      <filter>
+        filter "record['status'] = record['status'].to_i; [time, record]"
+      </filter>
     </filter>
 
 ### modify record(add value):
 
     <filter **>
-      type eval
-      filter1 "record['user_id'] = record['message'].split(':').last.to_i; [time, record]"
+      @type eval
+      <filter>
+        filter "record['user_id'] = record['message'].split(':').last.to_i; [time, record]"
+      </filter>
     </filter>
 
 #### input
@@ -94,13 +106,16 @@ Should return [time, record].
 Can not be used expression substitution.
 ```
 <match raw.apache.access>
-  filter1 "#{tag}"
+  @type eval_filter
+  <filter>
+    filter "#{tag}"
+  </filter>
 </match>
 ```
 
 '#' Is interpreted as the beginning of a comment.
 ```
-  filter1 #=> "\""
+  filter #=> "\""
 ```
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Or install it yourself as:
 
   config1 @hostname = `hostname -s`.chomp
 
-  filter1 [[tag, @hostname].join('.'), time, record] if record['method'] == 'GET'
+  filter1 "[[tag, @hostname].join('.'), time, record] if record['method'] == 'GET'"
 </match>
 ```
 
@@ -38,7 +38,7 @@ Or install it yourself as:
 
   config1 @hostname = YAML.load({'hostname' => 'web01'})['hostname']
 
-  filter1 [[tag, @hostname].join('.'), time, record] if record['method'] == 'GET'
+  filter1 "[[tag, @hostname].join('.'), time, record] if record['method'] == 'GET'"
 </match>
 ```
 

--- a/fluent-plugin-eval-filter.gemspec
+++ b/fluent-plugin-eval-filter.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "fluentd", "~> 0"
+  spec.add_dependency "fluentd", [">= 0.14.0", "< 2"]
   spec.add_development_dependency "rake", "~> 0"
   spec.add_development_dependency "test-unit", "~> 3.1.0"
 end

--- a/lib/fluent/plugin/filter_eval.rb
+++ b/lib/fluent/plugin/filter_eval.rb
@@ -4,7 +4,7 @@ module Fluent::Plugin
   class EvalFilter < Filter
     Fluent::Plugin.register_filter('eval', self)
 
-    config_param :requires, :string, default: nil, :desc => "require libraries."
+    config_param :requires, :array, default: [], :desc => "require libraries."
     config_section :filter, param_name: :filter_config, multi: true do
       config_param :filter, :string
       config_param :config, :string, default: ""
@@ -18,7 +18,7 @@ module Fluent::Plugin
       super
 
       if @requires
-        @requires.split(',').each do |lib|
+        @requires.each do |lib|
           begin
             require lib
           rescue Exception => e

--- a/lib/fluent/plugin/filter_eval.rb
+++ b/lib/fluent/plugin/filter_eval.rb
@@ -47,20 +47,14 @@ module Fluent::Plugin
 
     def filter(tag, time, record)
       begin
-        filtered_record = filter_record(tag, time, record)
-        return filtered_record if filtered_record
+        @filters.each do |filter|
+          filter_results = filter.call(tag, time, record)
+          return filter_results if filter_results
+        end
+        nil
       rescue => e
         router.emit_error_event(tag, time, record, e)
       end
-    end
-
-    private
-    def filter_record(tag, time, record)
-      @filters.each do |filter|
-        filter_results = filter.call(tag, time, record)
-        return filter_results if filter_results
-      end
-      nil
     end
   end
 end

--- a/lib/fluent/plugin/filter_eval.rb
+++ b/lib/fluent/plugin/filter_eval.rb
@@ -1,4 +1,6 @@
-module Fluent
+require 'fluent/plugin/filter'
+
+module Fluent::Plugin
   class EvalFilter < Filter
     Fluent::Plugin.register_filter('eval', self)
 
@@ -43,17 +45,13 @@ module Fluent
       end
     end
 
-    def filter_stream(tag, es)
-      new_es = MultiEventStream.new
-      es.each { |time, record|
-        begin
-          filtered_record = filter_record(tag, time, record)
-          new_es.add(*filtered_record) if filtered_record
-        rescue => e
-          router.emit_error_event(tag, time, record, e)
-        end
-      }
-      new_es
+    def filter(tag, time, record)
+      begin
+        filtered_record = filter_record(tag, time, record)
+        return filtered_record if filtered_record
+      rescue => e
+        router.emit_error_event(tag, time, record, e)
+      end
     end
 
     private

--- a/lib/fluent/plugin/filter_eval.rb
+++ b/lib/fluent/plugin/filter_eval.rb
@@ -5,9 +5,11 @@ module Fluent::Plugin
     Fluent::Plugin.register_filter('eval', self)
 
     config_param :requires, :array, default: [], :desc => "require libraries."
-    config_section :filter, param_name: :filter_config, multi: true do
+    config_section :rule, param_name: :filter_config, multi: true do
       config_param :filter, :string
-      config_param :config, :string, default: ""
+    end
+    config_section :eval, param_name: :eval_config, multi: true do
+      config_param :config, :string
     end
 
     def initialize
@@ -27,7 +29,7 @@ module Fluent::Plugin
         end
       end
 
-      @filter_config.each do |conf|
+      @eval_config.each do |conf|
         begin
           instance_eval("#{conf.config}")
         rescue Exception => e

--- a/lib/fluent/plugin/out_eval_filter.rb
+++ b/lib/fluent/plugin/out_eval_filter.rb
@@ -8,11 +8,6 @@ class Fluent::Plugin::EvalFilterOutput < Fluent::Plugin::Output
 
   config_param :requires, :string, default: nil, :desc => "require libraries."
 
-  # Define `router` method of v0.12 to support v0.10 or earlier
-  unless method_defined?(:router)
-    define_method("router") { Fluent::Engine }
-  end
-
   def configure(conf)
     super
 

--- a/lib/fluent/plugin/out_eval_filter.rb
+++ b/lib/fluent/plugin/out_eval_filter.rb
@@ -7,6 +7,10 @@ class Fluent::Plugin::EvalFilterOutput < Fluent::Plugin::Output
   helpers :event_emitter
 
   config_param :requires, :string, default: nil, :desc => "require libraries."
+  config_section :filter, param_name: :filter_config, multi: true do
+    config_param :filter, :string
+    config_param :config, :string, default: ""
+  end
 
   def configure(conf)
     super
@@ -30,20 +34,20 @@ class Fluent::Plugin::EvalFilterOutput < Fluent::Plugin::Output
     @add_tag_prefix = conf['add_tag_prefix']
     @add_tag_suffix = conf['add_tag_suffix']
 
-    conf.keys.select { |key| key =~ /^config\d+$/ }.sort_by { |key| key.sub('config', '').to_i }.each do |key|
+    @filter_config.each do |conf|
       begin
-        instance_eval("#{conf[key]}")
+        instance_eval("#{conf.config}")
       rescue Exception => e
-        raise Fluent::ConfigError, "#{key} #{conf[key]}\n" + e.to_s
+        raise Fluent::ConfigError, "#{key} #{conf.config}\n" + e.to_s
       end
     end
 
     @filters = []
-    conf.keys.select { |key| key =~ /^filter\d+$/ }.sort_by { |key| key.sub('filter', '').to_i }.each do |key|
+    @filter_config.each do |conf|
       begin
-        @filters << instance_eval("lambda do |tag, time, record| #{conf[key]} end")
+        @filters << instance_eval("lambda do |tag, time, record| #{conf.filter} end")
       rescue Exception => e
-        raise Fluent::ConfigError, "#{key} #{conf[key]}\n" + e.to_s
+        raise Fluent::ConfigError, "#{key} #{conf.filter}\n" + e.to_s
       end
     end
 

--- a/lib/fluent/plugin/out_eval_filter.rb
+++ b/lib/fluent/plugin/out_eval_filter.rb
@@ -6,7 +6,7 @@ class Fluent::Plugin::EvalFilterOutput < Fluent::Plugin::Output
 
   helpers :event_emitter
 
-  config_param :requires, :string, default: nil, :desc => "require libraries."
+  config_param :requires, :array, default: [], :desc => "require libraries."
   config_section :filter, param_name: :filter_config, multi: true do
     config_param :filter, :string
     config_param :config, :string, default: ""
@@ -16,7 +16,7 @@ class Fluent::Plugin::EvalFilterOutput < Fluent::Plugin::Output
     super
 
     if @requires
-      @requires.split(',').each do |lib|
+      @requires.each do |lib|
         begin
           require lib
         rescue Exception => e

--- a/lib/fluent/plugin/out_eval_filter.rb
+++ b/lib/fluent/plugin/out_eval_filter.rb
@@ -7,11 +7,12 @@ class Fluent::Plugin::EvalFilterOutput < Fluent::Plugin::Output
   helpers :event_emitter
 
   config_param :requires, :array, default: [], :desc => "require libraries."
-  config_section :filter, param_name: :filter_config, multi: true do
+  config_section :rule, param_name: :filter_config, multi: true do
     config_param :filter, :string
-    config_param :config, :string, default: ""
   end
-
+  config_section :eval, param_name: :eval_config, multi: true do
+    config_param :config, :string
+  end
   def configure(conf)
     super
 
@@ -34,7 +35,7 @@ class Fluent::Plugin::EvalFilterOutput < Fluent::Plugin::Output
     @add_tag_prefix = conf['add_tag_prefix']
     @add_tag_suffix = conf['add_tag_suffix']
 
-    @filter_config.each do |conf|
+    @eval_config.each do |conf|
       begin
         instance_eval("#{conf.config}")
       rescue Exception => e

--- a/lib/fluent/plugin/out_eval_filter.rb
+++ b/lib/fluent/plugin/out_eval_filter.rb
@@ -1,6 +1,10 @@
-class Fluent::EvalFilterOutput < Fluent::Output
+require 'fluent/plugin/output'
+
+class Fluent::Plugin::EvalFilterOutput < Fluent::Plugin::Output
 
   Fluent::Plugin.register_output('eval_filter', self)
+
+  helpers :event_emitter
 
   config_param :requires, :string, default: nil, :desc => "require libraries."
 
@@ -53,7 +57,7 @@ class Fluent::EvalFilterOutput < Fluent::Output
     end
   end
 
-  def emit(tag, es, chain)
+  def process(tag, es)
     tag = handle_tag(tag)
     es.each do |time, record|
       results = filter_record(tag, time, record)
@@ -63,7 +67,6 @@ class Fluent::EvalFilterOutput < Fluent::Output
         end
       end
     end
-    chain.next
   end
 
   def handle_tag(tag)

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -8,6 +8,7 @@ rescue Bundler::BundlerError => e
   exit e.status_code
 end
 require 'test/unit'
+require 'fluent/test/helpers'
 
 $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))
 $LOAD_PATH.unshift(File.dirname(__FILE__))
@@ -26,4 +27,5 @@ require 'fluent/plugin/out_eval_filter'
 require 'fluent/plugin/filter_eval'
 
 class Test::Unit::TestCase
+  include Fluent::Test::Helpers
 end

--- a/test/plugin/test_filter_eval.rb
+++ b/test/plugin/test_filter_eval.rb
@@ -28,9 +28,9 @@ class EvalFilterTest < Test::Unit::TestCase
   sub_test_case 'configure' do
     test 'check default' do
       config = %[
-        <filter>
+        <rule>
           filter "[time, record] if record['status'] == '404'"
-        </filter>
+        </rule>
       ]
       assert_nothing_raised {
         create_driver(config)
@@ -52,12 +52,12 @@ class EvalFilterTest < Test::Unit::TestCase
         {'status' => '401', 'message' => 'message'}
       ]
       config = %[
-        <filter>
+        <rule>
           filter "[time, record] if record['status'] == '404'"
-        </filter>
-        <filter>
+        </rule>
+        <rule>
           filter "[time, record] if record['status'] == '503'"
-        </filter>
+        </rule>
       ]
       es = filter(config, msgs)
       assert_equal(es.size, 2)
@@ -76,9 +76,9 @@ class EvalFilterTest < Test::Unit::TestCase
         {'status' => '401', 'message' => 'message'}
       ]
       config = %[
-        <filter>
+        <rule>
          filter "record['status'] = record['status'].to_i; [time, record]"
-        </filter>
+        </rule>
       ]
       es = filter(config, msgs)
       assert_equal(es.size, 5)
@@ -100,9 +100,9 @@ class EvalFilterTest < Test::Unit::TestCase
         {'status' => '401', 'message' => 'user_id:5'}
       ]
       config = %[
-        <filter>
+        <rule>
           filter "record['user_id'] = record['message'].split(':').last.to_i; [time, record]"
-        </filter>
+        </rule>
       ]
       es = filter(config, msgs)
       assert_equal(es.size, 5)
@@ -118,9 +118,9 @@ class EvalFilterTest < Test::Unit::TestCase
     test 'require yaml' do
       config = %[
         requires yaml
-        <filter>
+        <rule>
           filter "record.to_yaml; [time, record]"
-        </filter>
+        </rule>
       ]
       assert_nothing_raised {
         create_driver(config)
@@ -132,9 +132,9 @@ class EvalFilterTest < Test::Unit::TestCase
     test 'require libraries with whitespace' do
       d = create_driver(%[
         requires yaml, time
-        <filter>
+        <rule>
           filter "record.to_yaml; [Time.now.to_i, record]"
-        </filter>
+        </rule>
       ])
       assert_nothing_raised {
         d.run(default_tag: 'test') { d.feed({'key' => 'value'}) }
@@ -144,9 +144,9 @@ class EvalFilterTest < Test::Unit::TestCase
     test 'require error' do
       config = %[
         requires hoge
-        <filter>
+        <rule>
           filter "record.to_yaml; [time, record]"
-        </filter>
+        </rule>
       ]
       assert_raise(Fluent::ConfigError) do
         create_driver(config)

--- a/test/plugin/test_filter_eval.rb
+++ b/test/plugin/test_filter_eval.rb
@@ -7,7 +7,7 @@ class EvalFilterTest < Test::Unit::TestCase
 
   setup do
     Fluent::Test.setup
-    @time = Fluent::Engine.now
+    @time = event_time
   end
 
   def create_driver(conf = '')

--- a/test/plugin/test_filter_eval.rb
+++ b/test/plugin/test_filter_eval.rb
@@ -28,7 +28,9 @@ class EvalFilterTest < Test::Unit::TestCase
   sub_test_case 'configure' do
     test 'check default' do
       config = %[
-        filter1 "[time, record] if record['status'] == '404'"
+        <filter>
+          filter "[time, record] if record['status'] == '404'"
+        </filter>
       ]
       assert_nothing_raised {
         create_driver(config)
@@ -50,8 +52,12 @@ class EvalFilterTest < Test::Unit::TestCase
         {'status' => '401', 'message' => 'message'}
       ]
       config = %[
-        filter1 "[time, record] if record['status'] == '404'"
-        filter2 "[time, record] if record['status'] == '503'"
+        <filter>
+          filter "[time, record] if record['status'] == '404'"
+        </filter>
+        <filter>
+          filter "[time, record] if record['status'] == '503'"
+        </filter>
       ]
       es = filter(config, msgs)
       assert_equal(es.size, 2)
@@ -70,7 +76,9 @@ class EvalFilterTest < Test::Unit::TestCase
         {'status' => '401', 'message' => 'message'}
       ]
       config = %[
-        filter1 "record['status'] = record['status'].to_i; [time, record]"
+        <filter>
+         filter "record['status'] = record['status'].to_i; [time, record]"
+        </filter>
       ]
       es = filter(config, msgs)
       assert_equal(es.size, 5)
@@ -92,7 +100,9 @@ class EvalFilterTest < Test::Unit::TestCase
         {'status' => '401', 'message' => 'user_id:5'}
       ]
       config = %[
-        filter1 "record['user_id'] = record['message'].split(':').last.to_i; [time, record]"
+        <filter>
+          filter "record['user_id'] = record['message'].split(':').last.to_i; [time, record]"
+        </filter>
       ]
       es = filter(config, msgs)
       assert_equal(es.size, 5)
@@ -108,7 +118,9 @@ class EvalFilterTest < Test::Unit::TestCase
     test 'require yaml' do
       config = %[
         requires yaml
-        filter1 "record.to_yaml; [time, record]"
+        <filter>
+          filter "record.to_yaml; [time, record]"
+        </filter>
       ]
       assert_nothing_raised {
         create_driver(config)
@@ -120,7 +132,9 @@ class EvalFilterTest < Test::Unit::TestCase
     test 'require error' do
       config = %[
         requires hoge
-        filter1 "record.to_yaml; [time, record]"
+        <filter>
+          filter "record.to_yaml; [time, record]"
+        </filter>
       ]
       assert_raise(Fluent::ConfigError) do
         create_driver(config)

--- a/test/plugin/test_filter_eval.rb
+++ b/test/plugin/test_filter_eval.rb
@@ -129,6 +129,18 @@ class EvalFilterTest < Test::Unit::TestCase
       }
     end
 
+    test 'require libraries with whitespace' do
+      d = create_driver(%[
+        requires yaml, time
+        <filter>
+          filter "record.to_yaml; [Time.now.to_i, record]"
+        </filter>
+      ])
+      assert_nothing_raised {
+        d.run(default_tag: 'test') { d.feed({'key' => 'value'}) }
+      }
+    end
+
     test 'require error' do
       config = %[
         requires hoge

--- a/test/plugin/test_out_eval_filter.rb
+++ b/test/plugin/test_out_eval_filter.rb
@@ -16,17 +16,27 @@ class EvalFilterOutputTest < Test::Unit::TestCase
       create_driver('')
     end
     assert_raise(Fluent::ConfigError) do
-      create_driver(%[config1 @test = "\#{self.to_s}"])
+      create_driver(%[
+        <filter>
+          config @test = "\#{self.to_s}"
+        </filter>
+      ])
     end
     assert_raise(NameError) do
-      create_driver(%[filter1 "\#{tag}"])
+      create_driver(%[
+        <filter>
+          filter "\#{tag}"
+        </filter>
+      ])
     end
   end
 
   def test_remove_tag_prefix
     d = create_driver(%[
       remove_tag_prefix t1
-      filter1 tag
+      <filter>
+        filter tag
+      </filter>
     ])
 
     d.run(default_tag: 't1.t2.t3') { d.feed({}) }
@@ -39,7 +49,9 @@ class EvalFilterOutputTest < Test::Unit::TestCase
   def test_remove_tag_suffix
     d = create_driver(%[
       remove_tag_suffix t3
-      filter1 tag
+      <filter>
+        filter tag
+      </filter>
     ])
 
     d.run(default_tag: 't1.t2.t3') { d.feed({}) }
@@ -52,7 +64,9 @@ class EvalFilterOutputTest < Test::Unit::TestCase
   def test_add_tag_prefix
     d = create_driver(%[
       add_tag_prefix t0
-      filter1 tag
+      <filter>
+        filter tag
+      </filter>
     ])
 
     d.run(default_tag: 't1.t2.t3') { d.feed({}) }
@@ -65,7 +79,9 @@ class EvalFilterOutputTest < Test::Unit::TestCase
   def test_add_tag_suffix
     d = create_driver(%[
       add_tag_suffix t4
-      filter1 tag
+      <filter>
+        filter tag
+      </filter>
     ])
 
     d.run(default_tag: 't1.t2.t3') { d.feed({}) }
@@ -81,7 +97,9 @@ class EvalFilterOutputTest < Test::Unit::TestCase
       remove_tag_suffix t3
       add_tag_prefix t4
       add_tag_suffix t5
-      filter1 tag
+      <filter>
+        filter tag
+      </filter>
     ])
 
     d.run(default_tag: 't1.t2.t3') { d.feed({}) }
@@ -93,7 +111,9 @@ class EvalFilterOutputTest < Test::Unit::TestCase
 
   def test_drop_all_filter
     d = create_driver(%[
-      filter1 nil
+      <filter>
+        filter nil
+      </filter>
     ])
 
     d.run(default_tag: 't1.t2.t3') { d.feed({}) }
@@ -104,7 +124,9 @@ class EvalFilterOutputTest < Test::Unit::TestCase
 
   def test_modify_record_filter
     d = create_driver(%[
-      filter1 "record.merge!({'key' => 'value'})"
+      <filter>
+        filter "record.merge!({'key' => 'value'})"
+      </filter>
     ])
 
     d.run(default_tag: 'test') { d.feed({}) }
@@ -119,8 +141,12 @@ class EvalFilterOutputTest < Test::Unit::TestCase
 
   def test_replace_all_filter
     d = create_driver(%[
-      filter1 nil
-      filter2 "['tag', 0, {'key' => 'value'}]"
+      <filter>
+        filter nil
+      </filter>
+      <filter>
+        filter "['tag', 0, {'key' => 'value'}]"
+      </filter>
     ])
 
     d.run(default_tag: 'test') { d.feed({}) }
@@ -136,8 +162,12 @@ class EvalFilterOutputTest < Test::Unit::TestCase
 
   def test_conditional_filter
     d = create_driver(%[
-      filter1 "[['http', tag].join('.'), record] if /^http:/.match(record['url'])"
-      filter2 "(record['secure'] = true; [['https', tag].join('.'), record]) if /^https:/.match(record['url'])"
+      <filter>
+        filter "[['http', tag].join('.'), record] if /^http:/.match(record['url'])"
+      </filter>
+      <filter>
+        filter "(record['secure'] = true; [['https', tag].join('.'), record]) if /^https:/.match(record['url'])"
+      </filter>
     ])
 
     d.run(default_tag: 'test') do
@@ -163,8 +193,10 @@ class EvalFilterOutputTest < Test::Unit::TestCase
   def test_reference_to_an_instance_variable_filter
     hostname = `hostname -s`.chomp
     d = create_driver(%[
-      config1 @hostname = `hostname -s`.chomp
-      filter1 "[tag, @hostname].join('.')"
+      <filter>
+        config @hostname = `hostname -s`.chomp
+        filter "[tag, @hostname].join('.')"
+      </filter>
     ])
 
     d.run(default_tag: 'test') { d.feed({}) }
@@ -176,7 +208,9 @@ class EvalFilterOutputTest < Test::Unit::TestCase
 
   def test_amplify_tag_filter
     d = create_driver(%[
-      filter1 "(1..3).map { |n| tag + n.to_s }.to_enum"
+      <filter>
+        filter "(1..3).map { |n| tag + n.to_s }.to_enum"
+      </filter>
     ])
 
     d.run(default_tag: 'test') { d.feed({}) }
@@ -190,7 +224,9 @@ class EvalFilterOutputTest < Test::Unit::TestCase
 
   def test_amplify_time_filter
     d = create_driver(%[
-      filter1 "(1..3).map { |n| time + n }.to_enum"
+      <filter>
+        filter "(1..3).map { |n| time + n }.to_enum"
+      </filter>
     ])
 
     d.run(default_tag: 'test') { d.feed({}) }
@@ -204,7 +240,9 @@ class EvalFilterOutputTest < Test::Unit::TestCase
 
   def test_amplify_record_filter
     d = create_driver(%[
-      filter1 "(1..3).map { |n| record.merge({'n' => n}) }.to_enum"
+      <filter>
+        filter "(1..3).map { |n| record.merge({'n' => n}) }.to_enum"
+      </filter>
     ])
 
     d.run(default_tag: 'test') { d.feed({'key' => 'value'}) }
@@ -230,7 +268,9 @@ class EvalFilterOutputTest < Test::Unit::TestCase
 
   def test_split_record_filter
     d = create_driver(%[
-      filter1 "record.map { |key, value| [[tag, key].join('.'), {'key' => value}] }.to_enum"
+      <filter>
+        filter "record.map { |key, value| [[tag, key].join('.'), {'key' => value}] }.to_enum"
+      </filter>
     ])
 
     d.run(default_tag: 'test') { d.feed({'key1' => 'value1', 'key2' => 'value2', 'key3' => 'value3'}) }
@@ -253,7 +293,9 @@ class EvalFilterOutputTest < Test::Unit::TestCase
 
   def test_split_array_in_record_filter
     d = create_driver(%[
-      filter1 "record['array'].map { |v| {'value' => v} }.to_enum"
+      <filter>
+        filter "record['array'].map { |v| {'value' => v} }.to_enum"
+      </filter>
     ])
 
     d.run(default_tag: 'test') { d.feed({'array' => ['test1', 'test2', 'test3']}) }
@@ -274,7 +316,9 @@ class EvalFilterOutputTest < Test::Unit::TestCase
   def test_require_libraries
     d = create_driver(%[
       requires yaml
-      filter1 "record.to_yaml; ['tag', 0, record]"
+      <filter>
+        filter "record.to_yaml; ['tag', 0, record]"
+      </filter>
     ])
     assert_nothing_raised {
       d.run(default_tag: 'test') { d.feed({'key' => 'value'}) }
@@ -285,7 +329,9 @@ class EvalFilterOutputTest < Test::Unit::TestCase
     assert_raise(Fluent::ConfigError) do
       d = create_driver(%[
         requires hoge
-        filter1 "record.to_yaml; ['tag', 0, record]"
+        <filter>
+          filter "record.to_yaml; ['tag', 0, record]"
+        </filter>
       ])
     end
   end

--- a/test/plugin/test_out_eval_filter.rb
+++ b/test/plugin/test_out_eval_filter.rb
@@ -325,6 +325,18 @@ class EvalFilterOutputTest < Test::Unit::TestCase
     }
   end
 
+  def test_require_libraries_with_whitespace
+    d = create_driver(%[
+      requires yaml, time
+      <filter>
+        filter "record.to_yaml; ['tag', Time.now.to_i, record]"
+      </filter>
+    ])
+    assert_nothing_raised {
+      d.run(default_tag: 'test') { d.feed({'key' => 'value'}) }
+    }
+  end
+
   def test_require_error
     assert_raise(Fluent::ConfigError) do
       d = create_driver(%[


### PR DESCRIPTION
I've tried to migrate to use v0.14 Output and Filter Plugin API.
This PR contains major update change and also includes in breaking changes.
If above questions/problems are acceptable or reasonable for you, could you bump up major version if releasing new version of gem?
And please refer http://docs.fluentd.org/v0.14/articles/plugin-update-from-v12 before release new version.

Thanks in advance.